### PR TITLE
Nodegraph support

### DIFF
--- a/neo4j-datasource-plugin/pkg/plugin/plugin.go
+++ b/neo4j-datasource-plugin/pkg/plugin/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -145,7 +146,7 @@ func (d *Neo4JDatasource) query(query neo4JQuery) (backend.DataResponse, error) 
 		return response, errors.New(errMsg + " Please review log for more details.")
 	}
 
-	return toDataResponse(result)
+	return toGraphResponse(result)
 }
 
 func toDataResponse(result neo4j.Result) (backend.DataResponse, error) {
@@ -193,6 +194,90 @@ func toDataResponse(result neo4j.Result) (backend.DataResponse, error) {
 
 	// add the frames to the response.
 	response.Frames = append(response.Frames, frame)
+	return response, nil
+}
+
+// Return customized response for node graph panel
+func toGraphResponse(result neo4j.Result) (backend.DataResponse, error) {
+	response := backend.DataResponse{}
+
+	// Check if query has any keys. the query should return nodes as first key and relationship(edges)
+	// as second key. The function is sensitive to their order.
+	_, err := result.Keys()
+	if err != nil {
+		return response, err
+	}
+	// anonymous function to create dataframe with string fields
+	createStringFrame := func(frameName string, fields ...string) *data.Frame {
+		var dataFieldList []*data.Field
+		for _, field := range fields {
+			dataFieldList = append(dataFieldList, data.NewField(field, nil, []*string{}))
+		}
+		return data.NewFrame(frameName, dataFieldList...)
+	}
+	// newStringField := func(fieldName string) *data.Field {
+	// 	return data.NewField("id", nil, []*string{})
+	// }
+	// Create nodes dataframe with id, title(id to show), subTitle(first label) and detail as props.
+	nodesFrame := createStringFrame("nodes", "id", "title", "subTitle", "detail__props")
+	// Create edges dataframe with id, source(startNode), target(endNode), mainStat(label)
+	edgesFrame := createStringFrame("edges", "id", "source", "target", "mainStat")
+
+	var currentRecord *neo4j.Record
+	if result.Next() {
+		currentRecord = result.Record()
+	}
+
+	// a map of Id to empty string to prevent insert duplicate nodes in the dataframe
+	nodeIdMap := make(map[int64]string)
+	for currentRecord != nil {
+		values := result.Record().Values
+		nodeValuesInterface := values[0]
+		edgesValuesInterface := values[1]
+		nodeValuesList, ok := nodeValuesInterface.([]interface{})
+		if !ok {
+			panic("Node assertion error")
+		}
+		edgesValuesList, ok := edgesValuesInterface.([]interface{})
+		if !ok {
+			panic("Edge assertion error")
+		}
+		// Make nodes data frame
+		for _, node := range nodeValuesList {
+			v, ok := node.(dbtype.Node)
+			if !ok {
+				print("Node assertion error\n")
+			}
+			// check if this Id existed
+			if _, exists := nodeIdMap[v.Id]; !exists {
+				nodeIdMap[v.Id] = ""
+				IdString := strconv.FormatInt(v.Id, 10)
+				PropsString := toValue(v.Props)
+				nodesFrame.AppendRow(&IdString, &IdString, &v.Labels[0], PropsString)
+			}
+		}
+		// make edges dataframe
+		for _, edge := range edgesValuesList {
+			v, ok := edge.(dbtype.Relationship)
+			if !ok {
+				print("Edge assertion error\n")
+			}
+			IdString := strconv.FormatInt(v.Id, 10)
+			StartIdString := strconv.FormatInt(v.StartId, 10)
+			EndIdString := strconv.FormatInt(v.EndId, 10)
+			edgesFrame.AppendRow(&IdString, &StartIdString, &EndIdString, &v.Type)
+		}
+		if result.Next() {
+			currentRecord = result.Record()
+		} else {
+			currentRecord = nil
+		}
+	}
+	m := data.FrameMeta{PreferredVisualization: "nodeGraph"}
+	nodesFrame = nodesFrame.SetMeta(&m)
+	edgesFrame = edgesFrame.SetMeta(&m)
+	// add the frames to the response.
+	response.Frames = append(response.Frames, nodesFrame, edgesFrame)
 	return response, nil
 }
 

--- a/neo4j-datasource-plugin/pkg/plugin/plugin.go
+++ b/neo4j-datasource-plugin/pkg/plugin/plugin.go
@@ -145,8 +145,12 @@ func (d *Neo4JDatasource) query(query neo4JQuery) (backend.DataResponse, error) 
 		log.DefaultLogger.Error(errMsg, ERROR, err.Error())
 		return response, errors.New(errMsg + " Please review log for more details.")
 	}
-
-	return toGraphResponse(result)
+	// return appropriate format according to the choosen format(nodegraph or table)
+	if query.Format == "nodegraph" {
+		return toGraphResponse(result)
+	} else {
+		return toDataResponse(result)
+	}
 }
 
 func toDataResponse(result neo4j.Result) (backend.DataResponse, error) {
@@ -413,6 +417,7 @@ type neo4JQuery struct {
 	TimeRange backend.TimeRange
 
 	CypherQuery string `json:"cypherQuery"`
+	Format      string `json:"Format"`
 }
 
 type neo4JSettings struct {

--- a/neo4j-datasource-plugin/src/QueryEditor.tsx
+++ b/neo4j-datasource-plugin/src/QueryEditor.tsx
@@ -32,10 +32,10 @@ export class QueryEditor extends PureComponent<Props> {
   };
 
   resolveFormat = (value: string | undefined) => {
-    if (value === Format.Table) {
-      return Formats[0];
+    if (value === Format.NodeGraph) {
+      return Formats[1];
     }
-    return Formats[1];
+    return Formats[0];
   };
 
   render() {

--- a/neo4j-datasource-plugin/src/QueryEditor.tsx
+++ b/neo4j-datasource-plugin/src/QueryEditor.tsx
@@ -1,15 +1,41 @@
 import React, { PureComponent } from 'react';
-import { QueryField } from '@grafana/ui';
-import { QueryEditorProps } from '@grafana/data';
+import { InlineFieldRow, InlineFormLabel, QueryField, Select } from '@grafana/ui';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './datasource';
-import { MyDataSourceOptions, MyQuery } from './types';
+import { MyDataSourceOptions, MyQuery, Format } from './types';
 
 type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
+
+const Formats = [
+  {
+    label: 'Table',
+    value: Format.Table,
+    description: 'Table View',
+  },
+  {
+    label: 'Node Graph',
+    value: Format.NodeGraph,
+    description: 'Node Graph View',
+  },
+] as Array<SelectableValue<Format>>;
 
 export class QueryEditor extends PureComponent<Props> {
   onCypherQueryChange = (value: string) => {
     const { onChange, query } = this.props;
     onChange({ ...query, cypherQuery: value });
+  };
+
+  onFormatChanged = (selected: SelectableValue<Format>) => {
+    const { onChange, query, onRunQuery } = this.props;
+    onChange({ ...query, Format: selected.value || Format.Table });
+    onRunQuery();
+  };
+
+  resolveFormat = (value: string | undefined) => {
+    if (value === Format.Table) {
+      return Formats[0];
+    }
+    return Formats[1];
   };
 
   render() {
@@ -21,6 +47,17 @@ export class QueryEditor extends PureComponent<Props> {
           query={this.props.query.cypherQuery || ''}
           placeholder="Enter a cypher query"
         />
+        <InlineFieldRow>
+          <InlineFormLabel width={5}>Format</InlineFormLabel>
+          <Select
+            className="width-14"
+            value={this.resolveFormat(this.props.query.Format)}
+            options={Formats}
+            defaultValue={Formats[0]}
+            onChange={this.onFormatChanged}
+            width="auto"
+          />
+        </InlineFieldRow>
       </div>
     );
   }

--- a/neo4j-datasource-plugin/src/types.ts
+++ b/neo4j-datasource-plugin/src/types.ts
@@ -2,7 +2,18 @@ import { DataQuery, DataSourceJsonData } from '@grafana/data';
 
 export interface MyQuery extends DataQuery {
   cypherQuery: string;
+  Format: Format;
 }
+
+// Define Format enum for visualization format in the Query Editor
+export enum Format {
+  Table = 'table',
+  NodeGraph = 'nodegraph',
+}
+
+export type FormatInterface = {
+  [key in Format]: string;
+};
 
 /**
  * These are options configured for each DataSource instance


### PR DESCRIPTION
This PR Fixes #9

**Changes:**
- I've added a function _toGraphResponse_ that provides appropriate data frames for [node graph panel](https://grafana.com/docs/grafana/latest/visualizations/node-graph/). 
- This function is called instead of _toDataReponse_ only for proof of concept. Hence, we have to handle responses for different panels. I've explained more in the TODO section.

**Usage:**
1. Build the plugin
2. Give a query with nodes(p) and relationships(p) as final result keys. For example: 
`MATCH p=(tom:Person {name: "Tom Hanks"})-[]->(tomHanksMovies) RETURN nodes(p), relationships(p);`
3. Choose node graph panel to see the panel.

**Node Visualization:**
- title: node id
- subTitle: first label of the node
- detail__props: Properties of the node

**Edge Visualization:**
- hover on edge: type of the relationship

**TODO:**

- [x] Return different data frames with respect to the panels. i.e. _toDataResponse_ function has to be called for table panel and _toGraphResponsne_ function for node graph panel. One solution is to get a flag by the user in query editor to show us that he needs to see a graph response. For example, a radio button called "Graph".
- [x] All of the nodes are in gray color because arc__* is not mapped to any value. I don't know if it's appropriate to assign any color.
